### PR TITLE
Fix '-gt: unary operator expected'

### DIFF
--- a/sendtweet
+++ b/sendtweet
@@ -72,7 +72,7 @@ if [ -z "$1" ]; then
     die 'Cannot send an empty tweet!'
 fi
 
-if [ $(expr length "$1") -gt 140 ]; then
+if [ ${#1} -gt 140 ]; then
     die 'Tweet is more than 140 characters long!'
 fi
 


### PR DESCRIPTION
That line 75 errors for me with

`./sendtweet: line 75: [: -gt: unary operator expected`

This PR uses variable expansion to get the length of the string